### PR TITLE
Refactor: made the find_neighbors function to be a Board method.

### DIFF
--- a/life/life.py
+++ b/life/life.py
@@ -6,17 +6,52 @@ We assumme that cells at the edges of the board are dead.
 # CORE CLASSES
 class Board:
     def __init__(self, width, height):
-        del width  # not used by Board.__init__
-        self.width = self.height = height
+        """Initialize the Board class.
+
+        width -- number of columns
+        height -- number of rows
+        """
+        self.width = width
+        self.height = height
         self.live_cells = []
         # generate an n * n grid where n = self.width = self.height
         self.grid = [[Cell((x, y), self) for y in range(self.width)] for x in range(self.height)]
 
     def get_cell(self, pos):
+        """Return a cell given its coordinates.
+
+        pos -- tuple representing the cell's position on the board
+        """
         x, y = pos
         return self.grid[x][y]
 
+    # specify the rules for finding neighboring cells on a board
+    def find_neighbors(self, cell):
+        """Return the coordinates of the neighboring cells.
+
+        cell -- coordinates of the position of the cell on the board e.g. [0, 1]
+        """
+        x, y = cell.pos
+        grid_length = self.height
+
+        neighbors = []
+        x_max = x + 1 if x + 1 < grid_length else x
+        x_min = x - 1 if x - 1 >= 0 else x
+        y_max = y + 1 if y + 1 < grid_length else y
+        y_min = y - 1 if y - 1 >= 0 else y
+
+        for i in range(x_min, x_max + 1):
+            for j in range(y_min, y_max + 1):
+                if i != x or j != y:  # DeMorgan's 1st Law: negating conjuctions
+                    neighbors.append((i, j))
+
+        return neighbors
+
     def update(self):
+        """Update the cells' status for the next generation.
+
+        Uses the Conway's Game of Life rules (https://en.wikipedia.org/wiki/Conway%27s_Game_of_Life)
+        """
         # write code to update the board
         birth_row, death_row = [], []
 
@@ -31,13 +66,13 @@ class Board:
                     birth_row.append([x, y])
                 else:
                     if cell.status:
-                        death_row.append([x, y])
+                        death_row.append((x, y))
 
-        for x, y in birth_row:  # cells that will be born
-            self.grid[x][y].set_alive()
+        for pos in birth_row:  # cells that will be born
+            self.get_cell(pos).set_alive()
 
-        for x, y in death_row:  # cells that will die
-            self.grid[x][y].set_dead()
+        for pos in death_row:  # cells that will die
+            self.get_cell(pos).set_dead()
 
     def __str__(self):
         """Return string representation of the board."""
@@ -69,7 +104,7 @@ class Cell:
         Sums the values of each cell's status to get the number of live
         cells.
         """
-        neighbors = find_neighbors(self)
+        neighbors = self.board.find_neighbors(self)
         return sum([self.board.get_cell(pos).status for pos in neighbors])
 
     def set_dead(self):
@@ -86,41 +121,24 @@ class Cell:
 
 
 def activate_cells(board, positions):
-    for x, y in positions:
-        cell = board.grid[x][y]
-        cell.status = 1
+    """Change cells' status to alive (1) given their coordinates.
+
+    positions -- list of cell coordinates to activate (make alive)
+    """
+    for pos in positions:
+        cell = board.get_cell(pos)
+        cell.set_alive()
     return board
 
-def find_neighbors(cell):
-    """Return the coordinates of the neighboring cells.
-
-    cell -- coordinates of the position of the cell on the board e.g. [0, 1]
-    board -- n x n grid containing cells that are either dead (0) or alive (1) e.g. [[0, 0], [0, 1]]
-    """
-    x, y = cell.pos
-    grid_length = cell.board.height
-
-    neighbors = []
-    x_max = x + 1 if x + 1 < grid_length else x
-    x_min = x - 1 if x - 1 >= 0 else x
-    y_max = y + 1 if y + 1 < grid_length else y
-    y_min = y - 1 if y - 1 >= 0 else y
-
-    for i in range(x_min, x_max + 1):
-        for j in range(y_min, y_max + 1):
-            if i != x or j != y:  # DeMorgan's 1st Law: negating conjuctions
-                neighbors.append((i, j))
-
-    return neighbors
-
 def next_gen(board):
+    """Yield the next generation of the Game of Life board."""
     while True:
         yield board
         board.update()
 
 def main():
     board = Board(8, 8)
-    live_cells = [[2, 2], [2, 3], [3, 2], [3, 3], [4, 4], [4, 5], [5, 4], [5, 5]]
+    live_cells = [(2, 2), (2, 3), (3, 2), (3, 3), (4, 4), (4, 5), (5, 4), (5, 5)]
     activate_cells(board, live_cells)
     gen = next_gen(board)
 


### PR DESCRIPTION
At first, I wasn't sure if `find_neighbors` should be a `Board` or a `Cell` method. I then realized that a board has to define the rules to find cells surrounding a particular cell. Different types of boards might have different rules. For example, if we store our cells in a toroidal array, i.e., cells at the edges are neighbors with corresponding cells on the opposite edge. An infinite board would also have slightly different rules for finding neighboring cells than a finite board. I finally decided to add `find_neighbors` as a `Board` method so that other types of boards can overwrite this method if necessary.

I also made a couple of minor changes in this commit to clean up the codebase and maintain a consistent code style. For example, I used the `Board`'s `get_cell` method whenever I wanted to access a cell from the board.